### PR TITLE
Compatabillity with Flutter 3.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.3
+
+- **FIXED**: Removed unused dependency on package `analyzer`.
+
 ## 4.2.2
 
 - **FIXED**: Ignore formatting and coverage for generated file.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,6 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.0.0
   build: ^2.3.1
   pub_semver: ^2.1.4
   yaml: ^3.1.2


### PR DESCRIPTION
Newer Flutter SDKs depend on package `analyzer: ^7.4.5`, but because `pubspec_generator` depends on `analyzer: ^6.x.x` it is incompatible with newer Flutter SDKs

There is no need for `pubspec_generator` to have this direct dependency, because it is not used anywhere, therefore i removed it. If anyone needs it for development purposes then they may add it to `dev_dependencies`.